### PR TITLE
Fix crash when using remote docker instance

### DIFF
--- a/includes/gs-core.sh
+++ b/includes/gs-core.sh
@@ -102,7 +102,7 @@ function ph_type {
         RH_EXEC="${RIHOLE_BIN}"
     elif [ "$RH_IN_TYPE" == "docker" ]
     then
-        RH_EXEC="sudo ${ROCKER_BIN} exec $(sudo ${ROCKER_BIN} ps -qf ${ROCKER_CON}) pihole"
+        RH_EXEC="sudo ${ROCKER_BIN} exec $(sudo ${ROCKER_BIN} ps -qf name=${ROCKER_CON}) pihole"
     elif [ "$RH_IN_TYPE" == "podman" ]
     then
         RH_EXEC="sudo ${RODMAN_BIN} exec ${ROCKER_CON} pihole"


### PR DESCRIPTION
When trying to compare / sync and where the remote host is based on Docker, an error will be displayed as per below:
`invalid argument "pihole1" for "-f, --filter" flag: bad format of filter (expected name=value)`
`See 'docker ps --help'.`


I discovered that this is due to the missing `name=`. Upon adding this in, I found myself able to synchronise again.