### PR TITLE
Escape the remote system query

### DIFF
--- a/includes/gs-core.sh
+++ b/includes/gs-core.sh
@@ -102,7 +102,7 @@ function ph_type {
         RH_EXEC="${RIHOLE_BIN}"
     elif [ "$RH_IN_TYPE" == "docker" ]
     then
-        RH_EXEC="sudo ${ROCKER_BIN} exec $(sudo ${ROCKER_BIN} ps -qf name=${ROCKER_CON}) pihole"
+        RH_EXEC="sudo ${ROCKER_BIN} exec \$(sudo ${ROCKER_BIN} ps -qf name=${ROCKER_CON}) pihole"
     elif [ "$RH_IN_TYPE" == "podman" ]
     then
         RH_EXEC="sudo ${RODMAN_BIN} exec ${ROCKER_CON} pihole"


### PR DESCRIPTION
https://github.com/vmstan/gravity-sync/issues/157
https://github.com/vmstan/gravity-sync/discussions/158

When the script gs-core.sh is executed or sourced, the `$RH_EXEC` command is actually parsed on the local machine, and then used against the remote machine. This can lead to checking for a non-existent container name on the remote server, instead of properly parsing the remote system's configuration.

Example:
On load,

    RH_EXEC="sudo ${ROCKER_BIN} exec $(sudo ${ROCKER_BIN} ps -qf name=${ROCKER_CON}) pihole"
becomes `sudo /usr/bin/docker exec 0ce8b1d5571d pihole`, which is then used in an SSH command against the remote host, yielding:  

    [i] Inverting Tachyon Pulses
    [e] Updating Remote FTLDNS ConfigurationError: No such container: 0ce8b1d5571d
    [✗] Updating Remote FTLDNS Configuration
because, of course, the container ID doesn't exist on the remote host.

The fix is to escape the nested command execution within `gs-core.sh`, like so:

    --- gs-core.sh.orig     2021-02-17 17:43:53.732747200 -0700
    +++ gs-core.sh  2021-02-17 17:43:34.690296100 -0700
    @@ -102,7 +102,7 @@ function ph_type {
             RH_EXEC="${RIHOLE_BIN}"
         elif [ "$RH_IN_TYPE" == "docker" ]
         then
    -        RH_EXEC="sudo ${ROCKER_BIN} exec $(sudo ${ROCKER_BIN} ps -qf name=${ROCKER_CON}) pihole"
    +        RH_EXEC="sudo ${ROCKER_BIN} exec \$(sudo ${ROCKER_BIN} ps -qf name=${ROCKER_CON}) pihole"
         elif [ "$RH_IN_TYPE" == "podman" ]
         then
