### PR TITLE
Add the addition of an Environment Path variable in Crontab

### DIFF
--- a/includes/gs-automate.sh
+++ b/includes/gs-automate.sh
@@ -39,9 +39,16 @@ function task_automate {
             clear_cron
         fi
         
+        if [[ ${PATH} != *"/usr/sbin"* ]]
+        then
+            CRON_ENV_PATH="PATH=/bin:/usr/bin:/usr/sbin\n"
+        else
+            CRON_ENV_PATH=""
+        fi
+        
         MESSAGE="${UI_AUTO_CRON_SAVING}"
         echo_stat
-        (crontab -l 2>/dev/null; echo "*/${INPUT_AUTO_FREQ} * * * * ${BASH_PATH} ${LOCAL_FOLDR}/${GS_FILENAME} smart > ${LOG_PATH}/${CRONJOB_LOG}") | crontab -
+        (crontab -l 2>/dev/null; echo $CRON_ENV_PATH"*/${INPUT_AUTO_FREQ} * * * * ${BASH_PATH} ${LOCAL_FOLDR}/${GS_FILENAME} smart > ${LOG_PATH}/${CRONJOB_LOG}") | crontab -
         error_validate
     elif [ $INPUT_AUTO_FREQ == 0 ]
     then

--- a/includes/gs-automate.sh
+++ b/includes/gs-automate.sh
@@ -41,14 +41,14 @@ function task_automate {
         
         if [[ ${PATH} != *"/usr/sbin"* ]]
         then
-            CRON_ENV_PATH="PATH=/bin:/usr/bin:/usr/sbin\n"
+            CRON_ENV_PATH=$'PATH=/bin:/usr/bin:/usr/sbin\n'
         else
             CRON_ENV_PATH=""
         fi
         
         MESSAGE="${UI_AUTO_CRON_SAVING}"
         echo_stat
-        (crontab -l 2>/dev/null; echo $CRON_ENV_PATH"*/${INPUT_AUTO_FREQ} * * * * ${BASH_PATH} ${LOCAL_FOLDR}/${GS_FILENAME} smart > ${LOG_PATH}/${CRONJOB_LOG}") | crontab -
+        (crontab -l 2>/dev/null; echo "${CRON_ENV_PATH}*/${INPUT_AUTO_FREQ} * * * * ${BASH_PATH} ${LOCAL_FOLDR}/${GS_FILENAME} smart > ${LOG_PATH}/${CRONJOB_LOG}") | crontab -
         error_validate
     elif [ $INPUT_AUTO_FREQ == 0 ]
     then


### PR DESCRIPTION
When working through an issue raised which prevented the reload of FTLDNS, it was discovered that the cause of this is that PiHole performs service restarts using pre-systemd service commands, and that on some platforms, the program which performs this is not included within Cron's path.

When GravitySync is automated and calls PiHole, this causes the aforementioned problem where FTLDNS is unable to reload.

In this instance the problem was fixed by adding an Environmental path into the Crontab.

https://github.com/vmstan/gravity-sync/issues/193#issuecomment-828944251