### PR TITLE
Fix `find` command invoke (Issue #220)

### DIFF
--- a/includes/gs-backup.sh
+++ b/includes/gs-backup.sh
@@ -149,7 +149,7 @@ function backup_cleanup() {
     MESSAGE="${UI_BACKUP_PURGE}"
     echo_stat
     
-    find ${LOCAL_FOLDR}/${BACKUP_FOLD}/*.backup -mtime +${BACKUP_RETAIN} -type f -delete
+    find ${LOCAL_FOLDR}/${BACKUP_FOLD}/ -name "*.backup*" -mtime +${BACKUP_RETAIN} -type f -delete
     error_validate
     
     BACKUP_FOLDER_SIZE=$(du -h ${LOCAL_FOLDR}/${BACKUP_FOLD}  | sed 's/\s.*$//')


### PR DESCRIPTION
Previously `find` would return error.

I also had weird `.backup-journal` files in backup folder as well so I added wildcard at the end of the search string.