### PR TITLE
Make check for sudo privileges more accurate

### DIFF
--- a/gravity-sync
+++ b/gravity-sync
@@ -1653,8 +1653,9 @@ function validate_sudo_status {
     if [ ! "$EUID" -ne 0 ]; then
         OS_LOCAL_ADMIN=""
     else
-        OS_SUDO_CHECK=$(/usr/bin/sudo --validate)
-        if [ "$OS_SUDO_CHECK" -ne 0 ]; then
+        /usr/bin/sudo -u ${OS_CURRENT_USER} --validate
+        OS_SUDO_CHECK=$?
+        if [ $OS_SUDO_CHECK -ne 0 ]; then
             OS_LOCAL_ADMIN="nosudo"
         else
             OS_LOCAL_ADMIN="sudo"

--- a/gravity-sync
+++ b/gravity-sync
@@ -1653,8 +1653,8 @@ function validate_sudo_status {
     if [ ! "$EUID" -ne 0 ]; then
         OS_LOCAL_ADMIN=""
     else
-        OS_SUDO_CHECK=$(groups ${OS_CURRENT_USER} | grep -e 'sudo' -e 'wheel')
-        if [ "$OS_SUDO_CHECK" == "" ]; then
+        OS_SUDO_CHECK=$(/usr/bin/sudo --validate)
+        if [ "$OS_SUDO_CHECK" -ne 0 ]; then
             OS_LOCAL_ADMIN="nosudo"
         else
             OS_LOCAL_ADMIN="sudo"


### PR DESCRIPTION
The existing method of checking if the Gravity Sync user has sudo rights is flawed, in that it will break if the user is not in the `sudo` group (on Debian based distros) or the `wheel` group (on CentOS/RHEL distros).

A more accurate way of checking if a user has sudo privileges is using `sudo --validate` or `sudo -n true`; both of which return `0` if the user has sudo privileges.

This commit updates the `validate_sudo_status` function to use `sudo --validate` so that Gravity Sync is actually checking if a user has sudo privileges, rather than just checking group memberships.