### PR TITLE
Fix: GS_SSH_PORT can be changed now via  'gravity-sync config <NEW_PORT>' when already set in gravity-sync.conf. Fix: Initial sync of static DHCP and CNAME to 'empty pihole' now works. Enhancement: Various settings now settable via ENV vars (for Docker)

### DIFF
--- a/ENV.md
+++ b/ENV.md
@@ -82,4 +82,4 @@ Customize parameters for accessing the remote end via SSH
 Gravity-sync is locally installed as a github repo. In order to upgrade your local gravity-sync instance via `gravity-sync upgrade` to the latest version, the path to that git-repo must be known and can be specified below.
 | Variable | Default | Value | Description |
 | -------- | ------- | ----- | ---------- |
-| `GS_LOCAL_REPO` | `{<GS_ETC_PATH>/.gs"` | path | Local install path of the gravity-sync repo
+| `GS_LOCAL_REPO` | `<GS_ETC_PATH>/.gs"` | path | Local install path of the gravity-sync repo

--- a/ENV.md
+++ b/ENV.md
@@ -12,74 +12,74 @@ These tables are a list of all gravity-sync settings, that can be tweaked via EN
 
 ### Local and remote paths & settings
 These settings will determine, from where (locally) to where (remotely) will be synced and with which account/permissions
-| Variable | Default | Value | Description |
-| -------- | ------- | ----- | ---------- |
-| `LOCAL_PIHOLE_DIRECTORY` | `/etc/pihole` | path | Path to local pi-hole instance in the filesystem
-| `REMOTE_PIHOLE_DIRECTORY` | `/etc/pihole` | path | Path to remote pi-hole instanc in the filesystem
-| `LOCAL_DNSMASQ_DIRECTORY` | `/etc/dnsmasq.d` | path | Path to local dnsmasqd instance in the filesystem
-| `REMOTE_DNSMASQ_DIRECTORY`  | `/etc/dnsmasq.d` | path | Path to remote dnsmasqd instance in the filesystem
-| `LOCAL_FILE_OWNER`  | `pihole:pihole` | user:group | Local owner and group of the pi-hole config
-| `REMOTE_FILE_OWNER` | `pihole:pihole` | user:group | Remote owner and group of the pi-hole config
+| Variable                   | Default          | Value      | Description                                        |
+|----------------------------|------------------|------------|----------------------------------------------------|
+| `LOCAL_PIHOLE_DIRECTORY`   | `/etc/pihole`    | path       | Path to local pi-hole instance in the filesystem   |
+| `REMOTE_PIHOLE_DIRECTORY`  | `/etc/pihole`    | path       | Path to remote pi-hole instanc in the filesystem   |
+| `LOCAL_DNSMASQ_DIRECTORY`  | `/etc/dnsmasq.d` | path       | Path to local dnsmasqd instance in the filesystem  |
+| `REMOTE_DNSMASQ_DIRECTORY` | `/etc/dnsmasq.d` | path       | Path to remote dnsmasqd instance in the filesystem |
+| `LOCAL_FILE_OWNER`         | `pihole:pihole`  | user:group | Local owner and group of the pi-hole config        |
+| `REMOTE_FILE_OWNER`        | `pihole:pihole`  | user:group | Remote owner and group of the pi-hole config       |
 
 ### Docker specific settings
 Gravity-sync will check your system for a native pi-hole install first (on local and remote site) and if does not detect any, tests against docker/podman pi-hole instances.
 Here, you can specific the docker or podman container name, that gravity-sync should interact with.
-| Variable | Default | Value | Description |
-| -------- | ------- | ----- | ---------- |
-| `LOCAL_DOCKER_CONTAINER` | `pihole` | container name | Container name of pi-hole running locally
-| `REMOTE_DOCKER_CONTAINER` | `pihole` | container name | Container name of pi-hole running remotely
+| Variable                  | Default  | Value          | Description                                |
+|---------------------------|----------|----------------|--------------------------------------------|
+| `LOCAL_DOCKER_CONTAINER`  | `pihole` | container name | Container name of pi-hole running locally  |
+| `REMOTE_DOCKER_CONTAINER` | `pihole` | container name | Container name of pi-hole running remotely |
 
 ### Paths to standard files and folders
 These settings are most likely the same on all systems. No need to touch them but nice to be able to touch them, if necessary.
-| Variable | Default | Value | Description |
-| -------- | ------- | ----- | ---------- |
-| `DEFAULT_PIHOLE_DIRECTORY` | `/etc/pihole` | path | Docker/Podman: Path to pi-hole instance within a docker/podman containrt. Don't mix up with `LOCAL_PIHOLE_DIRECTORY`, which is only used against local pi-hole instances (non-dockerized).
-| `LOCAL_PIHOLE_BINARY`  | `/usr/local/bin/pihole` | path | Path to `pihole` binary on local system
-| `REMOTE_PIHOLE_BINARY` | `/usr/local/bin/pihole` |  path | Path to `pihole` binary on remote system
-| `LOCAL_FTL_BINARY` | `/usr/bin/pihole-FTL` | path | Path to `pihole-FTL` binary on local system
-| `REMOTE_FTL_BINARY` | `/usr/bin/pihole-FTL` | path | Path to `pihole-FTL` binary on remote system
-| `LOCAL_DOCKER_BINARY` | `/usr/bin/docker` | path | Path to `docker` binary on local system
-| `REMOTE_DOCKER_BINARY` | `/usr/bin/docker` | path | Path to `docker` binary on remote system
-| `LOCAL_PODMAN_BINARY` | `/usr/bin/podman` | path | Path to `podman` binary on local system
-| `REMOTE_PODMAN_BINARY` | `/usr/bin/podman` | path | Path to `podman` binary on remote system
-| `PIHOLE_CONTAINER_IMAGE` | `pihole/pihole` | path | Name of the default pi-hole docker image
+| Variable                   | Default                 | Value | Description                                                                                                                                                                                |
+|----------------------------|-------------------------|-------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DEFAULT_PIHOLE_DIRECTORY` | `/etc/pihole`           | path  | Docker/Podman: Path to pi-hole instance within a docker/podman containrt. Don't mix up with `LOCAL_PIHOLE_DIRECTORY`, which is only used against local pi-hole instances (non-dockerized). |
+| `LOCAL_PIHOLE_BINARY`      | `/usr/local/bin/pihole` | path  | Path to `pihole` binary on local system                                                                                                                                                    |
+| `REMOTE_PIHOLE_BINARY`     | `/usr/local/bin/pihole` | path  | Path to `pihole` binary on remote system                                                                                                                                                   |
+| `LOCAL_FTL_BINARY`         | `/usr/bin/pihole-FTL`   | path  | Path to `pihole-FTL` binary on local system                                                                                                                                                |
+| `REMOTE_FTL_BINARY`        | `/usr/bin/pihole-FTL`   | path  | Path to `pihole-FTL` binary on remote system                                                                                                                                               |
+| `LOCAL_DOCKER_BINARY`      | `/usr/bin/docker`       | path  | Path to `docker` binary on local system                                                                                                                                                    |
+| `REMOTE_DOCKER_BINARY`     | `/usr/bin/docker`       | path  | Path to `docker` binary on remote system                                                                                                                                                   |
+| `LOCAL_PODMAN_BINARY`      | `/usr/bin/podman`       | path  | Path to `podman` binary on local system                                                                                                                                                    |
+| `REMOTE_PODMAN_BINARY`     | `/usr/bin/podman`       | path  | Path to `podman` binary on remote system                                                                                                                                                   |
+| `PIHOLE_CONTAINER_IMAGE`   | `pihole/pihole`         | path  | Name of the default pi-hole docker image                                                                                                                                                   |
 
 ### Nitty-gritty finetuning the target files
 Here, you can specifiy the gravity, DNS (A, CNAME) and DHCP settings file of pi-hole. It is almost certain, that these filenames do never change (except upstream pi-hole decides so). Better do not touch them.
-| Variable | Default | Value | Description |
-| -------- | ------- | ----- | ---------- |
-| `PH_GRAVITY_FI` | `gravity.db` | file | The gravity filename (blocklist) of pihole
-| `PH_CUSTOM_DNS` | `custom.list`  | file | The custom DNS (A) filename of pihole
-| `PH_CNAME_CONF` | `05-pihole-custom-cname.conf` | file | The custom DNS (CNAME) filename of pihole
-| `PH_SDHCP_CONF` | `04-pihole-static-dhcp.conf` | file | The custom DHCP filename of pihole
+| Variable        | Default                       | Value | Description                                |
+|-----------------|-------------------------------|-------|--------------------------------------------|
+| `PH_GRAVITY_FI` | `gravity.db`                  | file  | The gravity filename (blocklist) of pihole |
+| `PH_CUSTOM_DNS` | `custom.list`                 | file  | The custom DNS (A) filename of pihole      |
+| `PH_CNAME_CONF` | `05-pihole-custom-cname.conf` | file  | The custom DNS (CNAME) filename of pihole  |
+| `PH_SDHCP_CONF` | `04-pihole-static-dhcp.conf`  | file  | The custom DHCP filename of pihole         |
 
 ### Backup Customization
-| Variable | Default | Value | Description |
-| -------- | ------- | ----- | ---------- |
-| `GS_BACKUP_TIMEOUT` | `240` | seconds | How long shall we allow a gravity.db backup task to run, before it is deemed to be timed out?
-| `GS_BACKUP_INTEGRITY_WAIT` | `5` | seconds | Some wait time, before integrity checks are performed on gravity.db
-| `GS_BACKUP_EXT` | `gsb` | file-extension | Local and remote gravity.db backup files will get this file-extension added before merge.
+| Variable                   | Default | Value          | Description                                                                                   |
+|----------------------------|---------|----------------|-----------------------------------------------------------------------------------------------|
+| `GS_BACKUP_TIMEOUT`        | `240`   | seconds        | How long shall we allow a gravity.db backup task to run, before it is deemed to be timed out? |
+| `GS_BACKUP_INTEGRITY_WAIT` | `5`     | seconds        | Some wait time, before integrity checks are performed on gravity.db                           |
+| `GS_BACKUP_EXT`            | `gsb`   | file-extension | Local and remote gravity.db backup files will get this file-extension added before merge.     |
 
 ### GS Folder/File Locations
-| Variable | Default | Value | Description |
-| -------- | ------- | ----- | ---------- |
-| `GS_ETC_PATH` | `/etc/gravity-sync` | path | Path to the gravity-sync work & config directory
-| `GS_CONFIG_FILE` | `gravity-sync.conf` | file | Name of the gravity.sync config file
-| `GS_SYNCING_LOG` | `gs-sync.log` | file  | Logfile for gravity-sync
-| `GS_GRAVITY_FI_MD5_LOG` | `gs-gravity.md5`  | file | Filename for storing `PH_GRAVITY_FI` hash (used for sync comparison locally and on remote)
-| `GS_CUSTOM_DNS_MD5_LOG` | `gs-clist.md5`  | file | Filename for storing `PH_CUSTOM_DNS` hash (used for sync comparison locally and on remote)
-| `GS_CNAME_CONF_MD5_LOG` | `05-pihole-custom-cname.conf.md5` | file | Filename for storing `PH_CNAME_CONF` hash (used for sync comparison locally and on remote)
-| `GS_SDHCP_CONF_MD5_LOG` | `04-pihole-static-dhcp.conf.md5` | file | Filename for storing `PH_SDHCP_CONF` hash (used for sync comparison locally and on remote)
+| Variable                | Default                           | Value | Description                                                                                |
+|-------------------------|-----------------------------------|-------|--------------------------------------------------------------------------------------------|
+| `GS_ETC_PATH`           | `/etc/gravity-sync`               | path  | Path to the gravity-sync work & config directory                                           |
+| `GS_CONFIG_FILE`        | `gravity-sync.conf`               | file  | Name of the gravity.sync config file                                                       |
+| `GS_SYNCING_LOG`        | `gs-sync.log`                     | file  | Logfile for gravity-sync                                                                   |
+| `GS_GRAVITY_FI_MD5_LOG` | `gs-gravity.md5`                  | file  | Filename for storing `PH_GRAVITY_FI` hash (used for sync comparison locally and on remote) |
+| `GS_CUSTOM_DNS_MD5_LOG` | `gs-clist.md5`                    | file  | Filename for storing `PH_CUSTOM_DNS` hash (used for sync comparison locally and on remote) |
+| `GS_CNAME_CONF_MD5_LOG` | `05-pihole-custom-cname.conf.md5` | file  | Filename for storing `PH_CNAME_CONF` hash (used for sync comparison locally and on remote) |
+| `GS_SDHCP_CONF_MD5_LOG` | `04-pihole-static-dhcp.conf.md5`  | file  | Filename for storing `PH_SDHCP_CONF` hash (used for sync comparison locally and on remote) |
 
 ### Remote SSH config
 Customize parameters for accessing the remote end via SSH
-| Variable | Default | Value | Description |
-| -------- | ------- | ----- | ---------- |
-| `GS_SSH_PORT` |  `22` | port | Port of the remote gravity-sync container/host
-| `GS_SSH_PKIF` | `<GS_ETC_PATH>/gravity-sync.rsa` | file | Path to the local SSH private key of gravity-sync, that will be used for pubkey auth against the remote
+| Variable      | Default                          | Value | Description                                                                                             |
+|---------------|----------------------------------|-------|---------------------------------------------------------------------------------------------------------|
+| `GS_SSH_PORT` | `22`                             | port  | Port of the remote gravity-sync container/host                                                          |
+| `GS_SSH_PKIF` | `<GS_ETC_PATH>/gravity-sync.rsa` | file  | Path to the local SSH private key of gravity-sync, that will be used for pubkey auth against the remote |
 
 ### Upgrade: Gravity-sync sourcecode location
 Gravity-sync is locally installed as a github repo. In order to upgrade your local gravity-sync instance via `gravity-sync upgrade` to the latest version, the path to that git-repo must be known and can be specified below.
-| Variable | Default | Value | Description |
-| -------- | ------- | ----- | ---------- |
-| `GS_LOCAL_REPO` | `<GS_ETC_PATH>/.gs"` | path | Local install path of the gravity-sync repo
+| Variable        | Default             | Value | Description                                 |
+|-----------------|---------------------|-------|---------------------------------------------|
+| `GS_LOCAL_REPO` | `<GS_ETC_PATH>/.gs` | path  | Local install path of the gravity-sync repo |

--- a/ENV.md
+++ b/ENV.md
@@ -1,0 +1,85 @@
+<p align="center">
+<img src="https://vmstan.com/content/images/2021/02/gs-logo.svg" width="300" alt="Gravity Sync">
+</p>
+
+<span align="center">
+
+# Gravity-sync ENVs
+
+</span>
+
+These tables are a list of all gravity-sync settings, that can be tweaked via ENVs. Keep in mind that some of them are stored in `/etc/gravity-sync/gravity-sync.conf` after running `gravity-sync configure` and that `gravity-sync.conf` has higher priority than ENVs.
+
+### Local and remote paths & settings
+These settings will determine, from where (locally) to where (remotely) will be synced and with which account/permissions
+| Variable | Default | Value | Description |
+| -------- | ------- | ----- | ---------- |
+| `LOCAL_PIHOLE_DIRECTORY` | `/etc/pihole` | path | Path to local pi-hole instance in the filesystem
+| `REMOTE_PIHOLE_DIRECTORY` | `/etc/pihole` | path | Path to remote pi-hole instanc in the filesystem
+| `LOCAL_DNSMASQ_DIRECTORY` | `/etc/dnsmasq.d` | path | Path to local dnsmasqd instance in the filesystem
+| `REMOTE_DNSMASQ_DIRECTORY`  | `/etc/dnsmasq.d` | path | Path to remote dnsmasqd instance in the filesystem
+| `LOCAL_FILE_OWNER`  | `pihole:pihole` | user:group | Local owner and group of the pi-hole config
+| `REMOTE_FILE_OWNER` | `pihole:pihole` | user:group | Remote owner and group of the pi-hole config
+
+### Docker specific settings
+Gravity-sync will check your system for a native pi-hole install first (on local and remote site) and if does not detect any, tests against docker/podman pi-hole instances.
+Here, you can specific the docker or podman container name, that gravity-sync should interact with.
+| Variable | Default | Value | Description |
+| -------- | ------- | ----- | ---------- |
+| `LOCAL_DOCKER_CONTAINER` | `pihole` | container name | Container name of pi-hole running locally
+| `REMOTE_DOCKER_CONTAINER` | `pihole` | container name | Container name of pi-hole running remotely
+
+### Paths to standard files and folders
+These settings are most likely the same on all systems. No need to touch them but nice to be able to touch them, if necessary.
+| Variable | Default | Value | Description |
+| -------- | ------- | ----- | ---------- |
+| `DEFAULT_PIHOLE_DIRECTORY` | `/etc/pihole` | path | Docker/Podman: Path to pi-hole instance within a docker/podman containrt. Don't mix up with `LOCAL_PIHOLE_DIRECTORY`, which is only used against local pi-hole instances (non-dockerized).
+| `LOCAL_PIHOLE_BINARY`  | `/usr/local/bin/pihole` | path | Path to `pihole` binary on local system
+| `REMOTE_PIHOLE_BINARY` | `/usr/local/bin/pihole` |  path | Path to `pihole` binary on remote system
+| `LOCAL_FTL_BINARY` | `/usr/bin/pihole-FTL` | path | Path to `pihole-FTL` binary on local system
+| `REMOTE_FTL_BINARY` | `/usr/bin/pihole-FTL` | path | Path to `pihole-FTL` binary on remote system
+| `LOCAL_DOCKER_BINARY` | `/usr/bin/docker` | path | Path to `docker` binary on local system
+| `REMOTE_DOCKER_BINARY` | `/usr/bin/docker` | path | Path to `docker` binary on remote system
+| `LOCAL_PODMAN_BINARY` | `/usr/bin/podman` | path | Path to `podman` binary on local system
+| `REMOTE_PODMAN_BINARY` | `/usr/bin/podman` | path | Path to `podman` binary on remote system
+| `PIHOLE_CONTAINER_IMAGE` | `pihole/pihole` | path | Name of the default pi-hole docker image
+
+### Nitty-gritty finetuning the target files
+Here, you can specifiy the gravity, DNS (A, CNAME) and DHCP settings file of pi-hole. It is almost certain, that these filenames do never change (except upstream pi-hole decides so). Better do not touch them.
+| Variable | Default | Value | Description |
+| -------- | ------- | ----- | ---------- |
+| `PH_GRAVITY_FI` | `gravity.db` | file | The gravity filename (blocklist) of pihole
+| `PH_CUSTOM_DNS` | `custom.list`  | file | The custom DNS (A) filename of pihole
+| `PH_CNAME_CONF` | `05-pihole-custom-cname.conf` | file | The custom DNS (CNAME) filename of pihole
+| `PH_SDHCP_CONF` | `04-pihole-static-dhcp.conf` | file | The custom DHCP filename of pihole
+
+### Backup Customization
+| Variable | Default | Value | Description |
+| -------- | ------- | ----- | ---------- |
+| `GS_BACKUP_TIMEOUT` | `240` | seconds | How long shall we allow a gravity.db backup task to run, before it is deemed to be timed out?
+| `GS_BACKUP_INTEGRITY_WAIT` | `5` | seconds | Some wait time, before integrity checks are performed on gravity.db
+| `GS_BACKUP_EXT` | `gsb` | file-extension | Local and remote gravity.db backup files will get this file-extension added before merge.
+
+### GS Folder/File Locations
+| Variable | Default | Value | Description |
+| -------- | ------- | ----- | ---------- |
+| `GS_ETC_PATH` | `/etc/gravity-sync` | path | Path to the gravity-sync work & config directory
+| `GS_CONFIG_FILE` | `gravity-sync.conf` | file | Name of the gravity.sync config file
+| `GS_SYNCING_LOG` | `gs-sync.log` | file  | Logfile for gravity-sync
+| `GS_GRAVITY_FI_MD5_LOG` | `gs-gravity.md5`  | file | Filename for storing `PH_GRAVITY_FI` hash (used for sync comparison locally and on remote)
+| `GS_CUSTOM_DNS_MD5_LOG` | `gs-clist.md5`  | file | Filename for storing `PH_CUSTOM_DNS` hash (used for sync comparison locally and on remote)
+| `GS_CNAME_CONF_MD5_LOG` | `05-pihole-custom-cname.conf.md5` | file | Filename for storing `PH_CNAME_CONF` hash (used for sync comparison locally and on remote)
+| `GS_SDHCP_CONF_MD5_LOG` | `04-pihole-static-dhcp.conf.md5` | file | Filename for storing `PH_SDHCP_CONF` hash (used for sync comparison locally and on remote)
+
+### Remote SSH config
+Customize parameters for accessing the remote end via SSH
+| Variable | Default | Value | Description |
+| -------- | ------- | ----- | ---------- |
+| `GS_SSH_PORT` |  `22` | port | Port of the remote gravity-sync container/host
+| `GS_SSH_PKIF` | `<GS_ETC_PATH>/gravity-sync.rsa` | file | Path to the local SSH private key of gravity-sync, that will be used for pubkey auth against the remote
+
+### Upgrade: Gravity-sync sourcecode location
+Gravity-sync is locally installed as a github repo. In order to upgrade your local gravity-sync instance via `gravity-sync upgrade` to the latest version, the path to that git-repo must be known and can be specified below.
+| Variable | Default | Value | Description |
+| -------- | ------- | ----- | ---------- |
+| `GS_LOCAL_REPO` | `{<GS_ETC_PATH>/.gs"` | path | Local install path of the gravity-sync repo

--- a/gravity-sync
+++ b/gravity-sync
@@ -1239,7 +1239,11 @@ function md5_recheck {
     fi
     
     if [ -f ${LOCAL_DNSMASQ_DIRECTORY}/${PH_CNAME_CONF} ]; then
-        if ${OS_SSH_CMD} -p ${GS_SSH_PORT} -i "${GS_SSH_PKIF}" ${REMOTE_USER}@${REMOTE_HOST} test -e ${REMOTE_DNSMASQ_DIRECTORY}/${PH_CNAME_CONF}; then
+        if ${OS_SSH_CMD} -p ${GS_SSH_PORT} -i "${GS_SSH_PKIF}" ${REMOTE_USER}@${REMOTE_HOST} test -e ${REMOTE_DNSMASQ_DIRECTORY}; then
+            CMD_TIMEOUT=$GS_BACKUP_TIMEOUT
+            CMD_REQUESTED="sudo touch ${REMOTE_DNSMASQ_DIRECTORY}/${PH_CNAME_CONF}"
+            create_ssh_cmd
+            
             REMOTE_CNAME_DNS="1"
             MESSAGE="${UI_HASHING_REHASHING} ${UI_CNAME_NAME}"
             echo_stat
@@ -1267,7 +1271,11 @@ function md5_recheck {
     fi
 
     if [ -f ${LOCAL_DNSMASQ_DIRECTORY}/${PH_SDHCP_CONF} ]; then
-        if ${OS_SSH_CMD} -p ${GS_SSH_PORT} -i "${GS_SSH_PKIF}" ${REMOTE_USER}@${REMOTE_HOST} test -e ${REMOTE_DNSMASQ_DIRECTORY}/${PH_SDHCP_CONF}; then
+        if ${OS_SSH_CMD} -p ${GS_SSH_PORT} -i "${GS_SSH_PKIF}" ${REMOTE_USER}@${REMOTE_HOST} test -e ${REMOTE_DNSMASQ_DIRECTORY}; then
+            CMD_TIMEOUT=$GS_BACKUP_TIMEOUT
+            CMD_REQUESTED="sudo touch ${REMOTE_DNSMASQ_DIRECTORY}/${PH_SDHCP_CONF}"
+            create_ssh_cmd
+            
             REMOTE_SDHCP_DNS="1"
             MESSAGE="${UI_HASHING_REHASHING} ${UI_SDHCP_NAME}"
             echo_stat

--- a/gravity-sync
+++ b/gravity-sync
@@ -19,61 +19,61 @@ GS_VERSION='4.0.4'
 # CUSTOM VARIABLES ###########################
 
 # Pi-hole Folder/File Customization - Only need to be customized when using containers
-LOCAL_PIHOLE_DIRECTORY='/etc/pihole' 			# replace in gravity-sync.conf to overwrite
-REMOTE_PIHOLE_DIRECTORY='/etc/pihole'			# replace in gravity-sync.conf to overwrite
-LOCAL_DNSMASQ_DIRECTORY='/etc/dnsmasq.d'        # replace in gravity-sync.conf to overwrite
-REMOTE_DNSMASQ_DIRECTORY='/etc/dnsmasq.d'       # replace in gravity-sync.conf to overwrite
-LOCAL_FILE_OWNER='pihole:pihole'			    # replace in gravity-sync.conf to overwrite
-REMOTE_FILE_OWNER='pihole:pihole'			    # replace in gravity-sync.conf to overwrite
+LOCAL_PIHOLE_DIRECTORY=${LOCAL_PIHOLE_DIRECTORY:-'/etc/pihole'}             # replace in gravity-sync.conf to overwrite
+REMOTE_PIHOLE_DIRECTORY=${REMOTE_PIHOLE_DIRECTORY:-'/etc/pihole'}           # replace in gravity-sync.conf to overwrite
+LOCAL_DNSMASQ_DIRECTORY=${LOCAL_DNSMASQ_DIRECTORY:-'/etc/dnsmasq.d'}        # replace in gravity-sync.conf to overwrite
+REMOTE_DNSMASQ_DIRECTORY=${REMOTE_DNSMASQ_DIRECTORY:-'/etc/dnsmasq.d'}      # replace in gravity-sync.conf to overwrite
+LOCAL_FILE_OWNER=${LOCAL_FILE_OWNER:-'pihole:pihole'}                       # replace in gravity-sync.conf to overwrite
+REMOTE_FILE_OWNER=${REMOTE_FILE_OWNER:-'pihole:pihole'}                     # replace in gravity-sync.conf to overwrite
 
 # Pi-hole Docker/Podman container name - Docker will pattern match anything set below
-LOCAL_DOCKER_CONTAINER='pihole'					# replace in gravity-sync.conf to overwrite
-REMOTE_DOCKER_CONTAINER='pihole'				# replace in gravity-sync.conf to overwrite
+LOCAL_DOCKER_CONTAINER=${LOCAL_DOCKER_CONTAINER:-'pihole'}                  # replace in gravity-sync.conf to overwrite
+REMOTE_DOCKER_CONTAINER=${REMOTE_DOCKER_CONTAINER:-'pihole'}                # replace in gravity-sync.conf to overwrite
 
 # STANDARD VARIABLES #########################
 
-DEFAULT_PIHOLE_DIRECTORY='/etc/pihole'			# Default Pi-hole data directory
-LOCAL_PIHOLE_BINARY='/usr/local/bin/pihole' 	# Local Pi-hole binary directory (default)
-REMOTE_PIHOLE_BINARY='/usr/local/bin/pihole' 	# Remote Pi-hole binary directory (default)
-LOCAL_FTL_BINARY='/usr/bin/pihole-FTL'          # Local FTL binary directory (default)
-REMOTE_FTL_BINARY='/usr/bin/pihole-FTL'         # Remote FTL binary directory (default)
-LOCAL_DOCKER_BINARY='/usr/bin/docker'		    # Local Docker binary directory (default)
-REMOTE_DOCKER_BINARY='/usr/bin/docker'		    # Remote Docker binary directory (default)
-LOCAL_PODMAN_BINARY='/usr/bin/podman'           # Local Podman binary directory (default)
-REMOTE_PODMAN_BINARY='/usr/bin/podman'          # Remote Podman binary directory (default)
-PIHOLE_CONTAINER_IMAGE='pihole/pihole'          # Official Pi-hole container image name
+DEFAULT_PIHOLE_DIRECTORY=${DEFAULT_PIHOLE_DIRECTORY:-'/etc/pihole'}         # Default Pi-hole data directory
+LOCAL_PIHOLE_BINARY=${LOCAL_PIHOLE_BINARY:-'/usr/local/bin/pihole'}         # Local Pi-hole binary directory (default)
+REMOTE_PIHOLE_BINARY=${REMOTE_PIHOLE_BINARY:-'/usr/local/bin/pihole'}       # Remote Pi-hole binary directory (default)
+LOCAL_FTL_BINARY=${LOCAL_FTL_BINARY:-'/usr/bin/pihole-FTL'}                 # Local FTL binary directory (default)
+REMOTE_FTL_BINARY=${REMOTE_FTL_BINARY:-'/usr/bin/pihole-FTL'}               # Remote FTL binary directory (default)
+LOCAL_DOCKER_BINARY=${LOCAL_DOCKER_BINARY:-'/usr/bin/docker'}               # Local Docker binary directory (default)
+REMOTE_DOCKER_BINARY=${REMOTE_DOCKER_BINARY:-'/usr/bin/docker'}             # Remote Docker binary directory (default)
+LOCAL_PODMAN_BINARY=${LOCAL_PODMAN_BINARY:-'/usr/bin/podman'}               # Local Podman binary directory (default)
+REMOTE_PODMAN_BINARY=${REMOTE_PODMAN_BINARY:-'/usr/bin/podman'}             # Remote Podman binary directory (default)
+PIHOLE_CONTAINER_IMAGE=${PIHOLE_CONTAINER_IMAGE:-'pihole/pihole'}           # Official Pi-hole container image name
 
 ###############################################
 ####### THE NEEDS OF THE MANY, OUTWEIGH #######
 ############ THE NEEDS OF THE FEW #############
 ###############################################
 
-PH_GRAVITY_FI='gravity.db' 			            # Pi-hole database file name
-PH_CUSTOM_DNS='custom.list'			            # Pi-hole DNS lookup filename
-PH_CNAME_CONF='05-pihole-custom-cname.conf'     # DNSMASQ CNAME alias file
-PH_SDHCP_CONF='04-pihole-static-dhcp.conf'      # DNSMASQ Static DHCP file
+PH_GRAVITY_FI=${PH_GRAVITY_FI:-'gravity.db'}                        # Pi-hole database file name
+PH_CUSTOM_DNS=${PH_CUSTOM_DNS:-'custom.list'}                       # Pi-hole DNS lookup filename
+PH_CNAME_CONF=${PH_CNAME_CONF:-'05-pihole-custom-cname.conf'}       # DNSMASQ CNAME alias file
+PH_SDHCP_CONF=${PH_SDHCP_CONF:-'04-pihole-static-dhcp.conf'}        # DNSMASQ Static DHCP file
 
 # Backup Customization
-GS_BACKUP_TIMEOUT='240'                         # replace in gravity-sync.conf to overwrite
-GS_BACKUP_INTEGRITY_WAIT='5'                    # replace in gravity-sync.conf to overwrite
-GS_BACKUP_EXT='gsb'                             # replace in gravity-sync.conf to overwrite
+GS_BACKUP_TIMEOUT=${GS_BACKUP_TIMEOUT:-'240'}                       # replace in gravity-sync.conf to overwrite
+GS_BACKUP_INTEGRITY_WAIT=${GS_BACKUP_INTEGRITY_WAIT:-'5'}           # replace in gravity-sync.conf to overwrite
+GS_BACKUP_EXT=${GS_BACKUP_EXT:-'gsb'}                               # replace in gravity-sync.conf to overwrite
 
 # GS Folder/File Locations
-GS_FILEPATH='/usr/local/bin/gravity-sync'			
-GS_ETC_PATH="/etc/gravity-sync"		                                # replace in gravity-sync.conf to overwrite
-GS_CONFIG_FILE='gravity-sync.conf' 	                                # replace in gravity-sync.conf to overwrite
-GS_SYNCING_LOG='gs-sync.log' 		                                # replace in gravity-sync.conf to overwrite
-GS_GRAVITY_FI_MD5_LOG='gs-gravity.md5'                              # replace in gravity-sync.conf to overwrite
-GS_CUSTOM_DNS_MD5_LOG='gs-clist.md5'                                # replace in gravity-sync.conf to overwrite
-GS_CNAME_CONF_MD5_LOG='05-pihole-custom-cname.conf.md5'             # replace in gravity-sync.conf to overwrite
-GS_SDHCP_CONF_MD5_LOG='04-pihole-static-dhcp.conf.md5'              # replace in gravity-sync.conf to overwrite
+GS_FILEPATH='/usr/local/bin/gravity-sync'
+GS_ETC_PATH=${GS_ETC_PATH:-"/etc/gravity-sync"}                                     # replace in gravity-sync.conf to overwrite
+GS_CONFIG_FILE=${GS_CONFIG_FILE:-'gravity-sync.conf'}                               # replace in gravity-sync.conf to overwrite
+GS_SYNCING_LOG=${GS_SYNCING_LOG:-'gs-sync.log'}                                     # replace in gravity-sync.conf to overwrite
+GS_GRAVITY_FI_MD5_LOG=${GS_GRAVITY_FI_MD5_LOG:-'gs-gravity.md5'}                    # replace in gravity-sync.conf to overwrite
+GS_CUSTOM_DNS_MD5_LOG=${GS_CUSTOM_DNS_MD5_LOG:-'gs-clist.md5'}                      # replace in gravity-sync.conf to overwrite
+GS_CNAME_CONF_MD5_LOG=${GS_CNAME_CONF_MD5_LOG:-'05-pihole-custom-cname.conf.md5'}   # replace in gravity-sync.conf to overwrite
+GS_SDHCP_CONF_MD5_LOG=${GS_SDHCP_CONF_MD5_LOG:-'04-pihole-static-dhcp.conf.md5'}    # replace in gravity-sync.conf to overwrite
 
 # SSH Customization
-GS_SSH_PORT='22' 						        # replace in gravity-sync.conf to overwrite
-GS_SSH_PKIF="${GS_ETC_PATH}/gravity-sync.rsa"   # replace in gravity-sync.conf to overwrite
+GS_SSH_PORT=${GS_SSH_PORT:-'22'}                                # replace in gravity-sync.conf to overwrite
+GS_SSH_PKIF=${GS_SSH_PKIF:-"${GS_ETC_PATH}/gravity-sync.rsa"}   # replace in gravity-sync.conf to overwrite
 
 # Github Customization
-GS_LOCAL_REPO="${GS_ETC_PATH}/.gs"              # replace in gravity-sync.conf to overwrite
+GS_LOCAL_REPO=${GS_LOCAL_REPO:-"${GS_ETC_PATH}/.gs"}            # replace in gravity-sync.conf to overwrite
 
 # OS Settings
 OS_DAEMON_PATH='/etc/systemd/system'
@@ -1683,7 +1683,7 @@ function task_configure {
     echo_good
 
     if [[ ${INPUT_SSH} =~ ^[0-9]+$ ]]; then
-        GS_SSH_PORT=${INPUT_SSH}
+        export GS_SSH_PORT=${INPUT_SSH}
         MESSAGE="TARGET HOST SSH PORT SET TO ${GS_SSH_PORT}"
         echo_warn
     fi
@@ -1996,7 +1996,13 @@ function advanced_config_generate {
 ## Delete Existing Configuration
 function config_delete {
     # shellcheck source=/etc/gravity-sync/gravity-sync.conf
+    if [ -n "${GS_SSH_PORT}" ]; then
+        _GS_SSH_PORT=${GS_SSH_PORT}
+    fi
     source ${GS_ETC_PATH}/${GS_CONFIG_FILE}
+    if [ -n "${_GS_SSH_PORT}" ]; then
+        GS_SSH_PORT=${_GS_SSH_PORT}
+    fi  
     MESSAGE="${GS_CONFIG_FILE} ${UI_CONFIG_ALREADY}"
     echo_warn
   

--- a/gravity-sync
+++ b/gravity-sync
@@ -1069,7 +1069,11 @@ function md5_compare {
     fi
 
     if [ -f ${LOCAL_DNSMASQ_DIRECTORY}/${PH_CNAME_CONF} ]; then
-        if ${OS_SSH_CMD} -p ${GS_SSH_PORT} -i "${GS_SSH_PKIF}" ${REMOTE_USER}@${REMOTE_HOST} test -e ${REMOTE_DNSMASQ_DIRECTORY}/${PH_CNAME_CONF}; then
+        if ${OS_SSH_CMD} -p ${GS_SSH_PORT} -i "${GS_SSH_PKIF}" ${REMOTE_USER}@${REMOTE_HOST} test -e ${REMOTE_DNSMASQ_DIRECTORY}; then
+            CMD_TIMEOUT=$GS_BACKUP_TIMEOUT
+            CMD_REQUESTED="sudo touch ${REMOTE_DNSMASQ_DIRECTORY}/${PH_CNAME_CONF}"
+            create_ssh_cmd
+            
             REMOTE_CNAME_DNS="1"
             MESSAGE="${UI_HASHING_HASHING} ${UI_CNAME_NAME}"
             echo_stat
@@ -1106,7 +1110,11 @@ function md5_compare {
     fi
 
     if [ -f ${LOCAL_DNSMASQ_DIRECTORY}/${PH_SDHCP_CONF} ]; then
-        if ${OS_SSH_CMD} -p ${GS_SSH_PORT} -i "${GS_SSH_PKIF}" ${REMOTE_USER}@${REMOTE_HOST} test -e ${REMOTE_DNSMASQ_DIRECTORY}/${PH_SDHCP_CONF}; then
+        if ${OS_SSH_CMD} -p ${GS_SSH_PORT} -i "${GS_SSH_PKIF}" ${REMOTE_USER}@${REMOTE_HOST} test -e ${REMOTE_DNSMASQ_DIRECTORY}; then
+            CMD_TIMEOUT=$GS_BACKUP_TIMEOUT
+            CMD_REQUESTED="sudo touch ${REMOTE_DNSMASQ_DIRECTORY}/${PH_SDHCP_CONF}"
+            create_ssh_cmd
+        
             REMOTE_SDHCP_DNS="1"
             MESSAGE="${UI_HASHING_HASHING} ${UI_SDHCP_NAME}"
             echo_stat

--- a/gravity-sync
+++ b/gravity-sync
@@ -1691,7 +1691,7 @@ function task_configure {
     echo_good
 
     if [[ ${INPUT_SSH} =~ ^[0-9]+$ ]]; then
-        export GS_SSH_PORT=${INPUT_SSH}
+        GS_SSH_PORT=${INPUT_SSH}
         MESSAGE="TARGET HOST SSH PORT SET TO ${GS_SSH_PORT}"
         echo_warn
     fi


### PR DESCRIPTION
This PR contains several changes and fixes.

**Fix:**: GS_SSH_PORT can be changed now via  ``gravity-sync config <NEW_PORT>`` when already set in gravity-sync.conf. 
When a custom SSH port has been once set earlier and written to gravity-sync.conf, using ``gravity-sync config <NEW_PORT>`` had no effect on the new port: The old port remained until manually changed in gravity-sync.conf. This is now fixed.

**Fix**: Initial sync of static DHCP and CNAME to 'empty pihole' now works. 
This fixes https://github.com/vmstan/gravity-sync/issues/377 by simply using "sudo touch <filename>" on the files it want to sync on the remote end.

**Enhancement**: Various settings now settable via ENV vars (for Docker)
Almost all config variables in gravity-sync rely on default-values set in the gravity-sync script itself, that then can be overwritten by the gravity-sync.conf file (if present). This is in principle absolutely fine but makes using Docker and docker-compose more demanding, since the easiest "docker-way" of setting config parameters is via ENVs.
The modifications now respect ENVs set by a container for various settings. If an ENV for a setting does not exist, the default value as stated in the gravity-sync script will be used. Finally, a gravity-sync.conf file still has highest priority over the settings value.