### PR TITLE
Fix the detect_xxx_pihole routines.

### DIFF
--- a/gravity-sync
+++ b/gravity-sync
@@ -1471,7 +1471,7 @@ function detect_local_pihole {
         LOCAL_PIHOLE_TYPE="default"
         echo_good
     elif hash docker 2>/dev/null; then
-        PH_FTL_CHECK=$(sudo docker container ls | grep 'pihole/pihole')
+        PH_FTL_CHECK=$(sudo docker container ls | grep ${PIHOLE_CONTAINER_IMAGE})
         if [ "$PH_FTL_CHECK" != "" ]; then
             LOCAL_PIHOLE_TYPE="docker"
             echo_good
@@ -1480,7 +1480,7 @@ function detect_local_pihole {
             echo_fail
         fi
     elif hash podman 2>/dev/null; then
-        PH_FTL_CHECK=$(sudo podman container ls | grep 'pihole/pihole')
+        PH_FTL_CHECK=$(sudo podman container ls | grep ${PIHOLE_CONTAINER_IMAGE})
         if [ "$PH_FTL_CHECK" != "" ]; then
             LOCAL_PIHOLE_TYPE="podman"
             echo_good
@@ -1502,8 +1502,8 @@ function detect_remote_pihole {
         REMOTE_PIHOLE_TYPE="default"
         echo_good
     else   
-        REMOTE_DETECT_DOCKER=$(${OS_SSH_CMD} -p ${GS_SSH_PORT} -i "${GS_SSH_PKIF}" ${REMOTE_USER}@${REMOTE_HOST} "sudo docker container ls | grep 'pihole/pihole'" 2>/dev/null)
-        REMOTE_DETECT_PODMAN=$(${OS_SSH_CMD} -p ${GS_SSH_PORT} -i "${GS_SSH_PKIF}" ${REMOTE_USER}@${REMOTE_HOST} "sudo podman container ls | grep 'pihole/pihole'" 2>/dev/null)
+        REMOTE_DETECT_DOCKER=$(${OS_SSH_CMD} -p ${GS_SSH_PORT} -i "${GS_SSH_PKIF}" ${REMOTE_USER}@${REMOTE_HOST} "sudo docker container ls | grep ${PIHOLE_CONTAINER_IMAGE}" 2>/dev/null)
+        REMOTE_DETECT_PODMAN=$(${OS_SSH_CMD} -p ${GS_SSH_PORT} -i "${GS_SSH_PKIF}" ${REMOTE_USER}@${REMOTE_HOST} "sudo podman container ls | grep ${PIHOLE_CONTAINER_IMAGE}" 2>/dev/null)
 
         if [ "${REMOTE_DETECT_DOCKER}" != "" ]; then
             REMOTE_PIHOLE_TYPE="docker"


### PR DESCRIPTION
The ghcr.io/pi-hole/pihole image is not supported by gravity-sync v4.0.4. This PR addresses this limitation.

It updates gravity-sync to respect its PIHOLE_CONTAINER_IMAGE variable in its detect_local_pihole, and
detect_remote_pihole functions.

From the commit message:

Fix the detect_xxx_pihole routines to respect the configurable PIHOLE_CONTAINER_IMAGE variable.

The ghcr.io/pi-hole/pihole image is also released by the Pi-hole project, just as the pihole/pihole image.

This commit enables ghcr.io image usage by adding the following to the /etc/gravity-sync.conf file:

PIHOLE_CONTAINER_IMAGE='ghcr.io/pi-hole/pihole'