### PR TITLE
Sudo security patches

### DIFF
--- a/gravity-sync
+++ b/gravity-sync
@@ -114,7 +114,9 @@ UI_PULL_REMOTE='Pulling the remote'
 UI_PUSH_LOCAL='Pushing the local'
 UI_REPLACE_LOCAL='Replacing the local'
 UI_FTLDNS_CONFIG_PULL_RELOAD='Reloading local FTLDNS services'
+UI_FTLDNS_CONFIG_PULL_UPDATE='Updating local FTLDNS configuration'
 UI_FTLDNS_CONFIG_PUSH_RELOAD='Reloading remote FTLDNS services'
+UI_FTLDNS_CONFIG_PUSH_UPDATE='Updating remote FTLDNS configuration'
 UI_LOGGING_RECENT_COMPLETE='Recent complete executions of'
 UI_BACKUP_REMOTE='Performing backup of remote'
 UI_BACKUP_LOCAL='Performing backup of local'
@@ -413,7 +415,7 @@ function pull_gs_sdhcp {
 function pull_gs_reload {
     sleep 1
 
-    MESSAGE="Updating local FTLDNS configuration"
+    MESSAGE="${UI_FTLDNS_CONFIG_PULL_UPDATE}"
     echo_stat
     ${PH_EXEC} restartdns reload-lists >/dev/null 2>&1
     error_validate
@@ -575,10 +577,10 @@ function push_gs_sdhcp {
 function push_gs_reload {
     sleep 1
 
-    MESSAGE="Updating remote FTLDNS configuration"
+    MESSAGE="${UI_FTLDNS_CONFIG_PUSH_UPDATE}"
     echo_stat
     CMD_TIMEOUT=$GS_BACKUP_TIMEOUT
-    CMD_REQUESTED="${RH_EXEC} restartdns reload-lists"
+    CMD_REQUESTED="sudo ${RH_EXEC} restartdns reload-lists"
     create_ssh_cmd
 
     if [ "${GS_TASK_TYPE}" == SMART ]; then
@@ -586,14 +588,14 @@ function push_gs_reload {
             MESSAGE="${UI_FTLDNS_CONFIG_PUSH_RELOAD}"
             echo_stat
             CMD_TIMEOUT=$GS_BACKUP_TIMEOUT
-            CMD_REQUESTED="${RH_EXEC} restartdns"
+            CMD_REQUESTED="sudo ${RH_EXEC} restartdns"
             create_ssh_cmd
         fi
     else
         MESSAGE="${UI_FTLDNS_CONFIG_PUSH_RELOAD}"
         echo_stat
         CMD_TIMEOUT=$GS_BACKUP_TIMEOUT
-        CMD_REQUESTED="${RH_EXEC} restartdns"
+        CMD_REQUESTED="sudo ${RH_EXEC} restartdns"
         create_ssh_cmd
     fi
 }

--- a/gravity-sync
+++ b/gravity-sync
@@ -1656,7 +1656,7 @@ function task_sudo {
     echo_stat
 
     NEW_SUDO_USER=$(whoami)
-    echo -e "${NEW_SUDO_USER} ALL=(ALL) NOPASSWD: ALL" | sudo tee ${GS_LOCAL_REPO}/templates/gs-nopasswd.sudo 1> /dev/null
+    echo -e "${NEW_SUDO_USER} ALL=(ALL:ALL) NOPASSWD: /usr/bin/mv, /usr/bin/rsync, /usr/local/bin/gravity-sync, /usr/bin/touch, /usr/bin/chown, /usr/bin/chmod, /usr/bin/rm, /usr/bin/cp, /usr/bin/tee, /usr/bin/sed, /usr/bin/git, /usr/bin/systemctl, /usr/bin/journalctl, ${LOCAL_DOCKER_BINARY}, ${LOCAL_PODMAN_BINARY}, ${LOCAL_FTL_BINARY}, ${LOCAL_PIHOLE_BINARY}" | sudo tee ${GS_LOCAL_REPO}/templates/gs-nopasswd.sudo 1> /dev/null
     error_validate
 
     MESSAGE="Installing sudoers.d file on $HOSTNAME"

--- a/templates/gs-nopasswd.sudo
+++ b/templates/gs-nopasswd.sudo
@@ -1,1 +1,1 @@
-pi ALL=NOPASSWD: /etc/pihole
+pi ALL=(ALL:ALL) NOPASSWD: /usr/bin/mv, /usr/bin/rsync, /usr/local/bin/gravity-sync, /usr/bin/touch, /usr/bin/chown, /usr/bin/chmod, /usr/bin/rm, /usr/bin/cp, /usr/bin/tee, /usr/bin/sed, /usr/bin/git, /usr/bin/systemctl, /usr/bin/journalctl, /usr/bin/docker, /usr/bin/podman, /usr/bin/pihole-FTL, /usr/local/bin/pihole


### PR DESCRIPTION
I ran into some issues during my installation, I was finding on a brand new pi hole install that some of the commands needed sudo to run, and were failing when reviewing the systemd journal (but would work manually). This patch resolves this, and also creates a much more tailored sudoers file which correctly addresses the requirements of the script and nothing more.